### PR TITLE
eliminando hover por toggle

### DIFF
--- a/public/css/header.css
+++ b/public/css/header.css
@@ -25,14 +25,26 @@ nav ul li{
     display: inline-block;
     line-height: 40px;
 }
-nav ul li a, a{
+nav ul li a, a, .btn.btn-secondary.dropdown-toggle{
     color: #fff;
     font-family: Barlow, sans-serif;
     font-size: 18px;
     padding: 7px 13px;
     border-radius: 3px;
+    font-weight: 500;
 }
-
+.btn.btn-secondary.dropdown-toggle {
+    background-color: #003084;
+    border: none;
+    margin-top: -5px;
+}
+.btn.btn-secondary.dropdown-toggle:hover {
+    color: #F9C440;
+    background-color: #06225B;
+}
+.dropdown-menu.show, li.dropdown-item:hover {
+    background-color: #003084;
+}
 h1, h2, h3, p {
     font-family: Barlow, sans-serif;
 }
@@ -71,7 +83,6 @@ nav ul li ul.dropdown{
     padding: 0;
 }
 nav ul li ul.dropdown li{
-    font-weight: 500;
     display: block;
     line-height: 30px;
     border: 1px solid #ccc;
@@ -82,7 +93,7 @@ nav ul li ul.dropdown li a{
     width: 100%;
     padding: 7px 13px;
 }
-nav ul li a:hover{
+nav ul li a:hover, .dropdown-item{
     background: #06225B;
     color: #F9C440;
 }
@@ -131,9 +142,11 @@ nav ul li:hover ul.dropdown{
     nav ul li a{
         font-size: 20px;
     }
-    li a:hover, li a.active{
-        background: none;
-        color: white;
+    li.dropdown-item {
+        margin: 0;
+    }
+    .dropdown-menu.show {
+        height: auto;
     }
     #check:checked ~ul{
         left: 0;

--- a/src/views/contacto.ejs
+++ b/src/views/contacto.ejs
@@ -39,6 +39,8 @@
     </div>
 
     <%- include('./partials/footer.ejs') %>
-
+    
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" 
+    integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/views/nosotros.ejs
+++ b/src/views/nosotros.ejs
@@ -65,5 +65,7 @@
 
     <%- include('./partials/footer.ejs') %>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" 
+    integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -27,12 +27,13 @@
         </a>
         <ul class="nav-menu">
             <li><a href="/">INICIO</a></li>
-            <li><a href="/products">PRODUCTOS ▾</a>
-                <ul class="dropdown">
-                    <li><a href="/products/neumaticos">Neumáticos</a></li>
-                    <li><a href="/products/aceites">Aceites</a></li>
-                    <li><a href="/products/baterias">Baterías</a></li>
-                </ul>
+            <li><a class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" 
+                aria-expanded="false" href="/products">PRODUCTOS</a>
+                    <ul class="dropdown-menu">
+                        <li class="dropdown-item"><a href="/products/neumaticos">Neumáticos</a></li>
+                        <li class="dropdown-item"><a href="/products/aceites">Aceites</a></li>
+                        <li class="dropdown-item"><a href="/products/baterias">Baterías</a></li>
+                    </ul>
             </li>
             <li><a href="/services">SERVICIOS</a></li>
             <li><a href="/us">SOBRE NOSOTROS</a></li>

--- a/src/views/products/products.ejs
+++ b/src/views/products/products.ejs
@@ -37,5 +37,8 @@
         </section>
     </main>
     <%- include('../partials/footer.ejs') %>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" 
+    integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
El objetivo es mostrar el submenu de productos en la barra desplegable en dispositivos moviles. La pseudoclase hover no funciona en mobile.